### PR TITLE
Dev 1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.7]
+
+### Added
+
+- Added `amplicon_16s`, `amplicon_18s`, `amplicon_its` profiles for runsheet generation.
+
+### Changed
+
+- Removed host organism dependency for amplicon runsheet generation.
+- Forced technology type (`16S`/`18S`/`ITS`) inclusion in all amplicon runsheet names.
+- Removed assay table name inclusion from runsheet names for datasets with multiple amplicon assay tables (verified all current OSD datasets have at most one amplicon assay table per technology type).
+- *Note: Support for combined '16S and ITS' assay type (OSD-249) is pending.*
+
+### Fixed
+
+- Dockerfile now sets the PATH environment variable using ENV.
+- Resolved Docker build dependency conflict (PyYAML) using `--ignore-installed` during pip install.
+
 ## [1.3.6]
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . /app
 # set ownership and permissions
 RUN chown -R genuser:genuser /app && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 && \
-    pip install /app &&  \
+    pip install --ignore-installed PyYAML /app &&  \
     # save space in image by removing source code after pip install
     rm -rf /app && \
     echo "export PATH=/home/genuser/.local/bin:$PATH" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,10 @@ RUN chown -R genuser:genuser /app && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 && \
     pip install --ignore-installed PyYAML /app &&  \
     # save space in image by removing source code after pip install
-    rm -rf /app && \
-    echo "export PATH=/home/genuser/.local/bin:$PATH" >> ~/.bashrc
+    rm -rf /app
+
+# Add local bin to path
+ENV PATH=/home/genuser/.local/bin:$PATH
 
 # swith to user
 USER genuser

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ dpt isa to-runsheet <accession> --config-type CONFIG_TYPE --config-version CONFI
 
 Converts an ISA archive to a runsheet compatible with GeneLab processing workflows.
 
+Supported `CONFIG_TYPE` values include:
+* `bulkRNASeq`
+* `microarray`
+* `methylSeq`
+* `metagenomics`
+* `amplicon` (Generic amplicon, creates runsheets for any 16S, 18S, or ITS assays found in the ISA archive)
+* `amplicon_16s` (Specifically targets 16S assays)
+* `amplicon_its` (Specifically targets ITS assays)
+* `amplicon_18s` (Specifically targets 18S assays)
+
 **Examples:**
 ```bash
 # Convert ISA archive to a bulkRNASeq runsheet
@@ -44,6 +54,17 @@ dpt isa to-runsheet GLDS-194 --config-type bulkRNASeq --config-version latest --
 
 # Convert ISA archive to a microarray runsheet with specific output directory
 dpt isa to-runsheet OSD-194 --config-type microarray --config-version v1 --isa-archive OSD-194_metadata_OSD-194-ISA.zip --output-dir /path/to/output
+
+# Convert ISA archive targeting only 16S amplicon assays
+dpt isa to-runsheet OSD-694 --config-type amplicon_16s --isa-archive OSD-694_metadata_OSD-694-ISA.zip
+# Output: OSD-694_16S_amplicon_v1_runsheet.csv
+
+# Convert ISA archive using the generic amplicon config
+# This will find all amplicon assays (16S, 18S, ITS) and create separate runsheets
+dpt isa to-runsheet OSD-694 --config-type amplicon --isa-archive OSD-694_metadata_OSD-694-ISA.zip
+# Example Outputs (if both 16S and ITS assays are present):
+# OSD-694_16S_amplicon_v1_runsheet.csv
+# OSD-694_ITS_amplicon_v1_runsheet.csv
 ```
 
 ### OSD API Interaction

--- a/dp_tools/config/amplicon_16s_v1.yaml
+++ b/dp_tools/config/amplicon_16s_v1.yaml
@@ -178,12 +178,6 @@ ISA Meta:
   Valid Study Assay Technology And Measurement Types:
     - measurement: "Amplicon Sequencing"
       technology: "16S"
-    - measurement: "Amplicon Sequencing"
-      technology: "18S"
-    # - measurement: "Amplicon Sequencing"
-    #   technology: "16S and ITS"
-    - measurement: "Amplicon Sequencing"
-      technology: "ITS"
 
   # this is prepended to all file names in the curation assay table
   Global file prefix: "{datasystem}_amplicon_"

--- a/dp_tools/config/amplicon_16s_vLatest.yaml
+++ b/dp_tools/config/amplicon_16s_vLatest.yaml
@@ -1,5 +1,5 @@
 # TOP LEVEL
-NAME: "amplicon"
+NAME: "amplicon_16s"
 VERSION: "1"
 
 Staging:
@@ -178,12 +178,6 @@ ISA Meta:
   Valid Study Assay Technology And Measurement Types:
     - measurement: "Amplicon Sequencing"
       technology: "16S"
-    - measurement: "Amplicon Sequencing"
-      technology: "18S"
-    # - measurement: "Amplicon Sequencing"
-    #   technology: "16S and ITS"
-    - measurement: "Amplicon Sequencing"
-      technology: "ITS"
 
   # this is prepended to all file names in the curation assay table
   Global file prefix: "{datasystem}_amplicon_"

--- a/dp_tools/config/amplicon_18s_v1.yaml
+++ b/dp_tools/config/amplicon_18s_v1.yaml
@@ -177,13 +177,8 @@ Staging:
 ISA Meta:
   Valid Study Assay Technology And Measurement Types:
     - measurement: "Amplicon Sequencing"
-      technology: "16S"
-    - measurement: "Amplicon Sequencing"
       technology: "18S"
-    # - measurement: "Amplicon Sequencing"
-    #   technology: "16S and ITS"
-    - measurement: "Amplicon Sequencing"
-      technology: "ITS"
+
 
   # this is prepended to all file names in the curation assay table
   Global file prefix: "{datasystem}_amplicon_"

--- a/dp_tools/config/amplicon_18s_vLatest.yaml
+++ b/dp_tools/config/amplicon_18s_vLatest.yaml
@@ -1,5 +1,5 @@
 # TOP LEVEL
-NAME: "amplicon"
+NAME: "amplicon_18s"
 VERSION: "1"
 
 Staging:
@@ -177,13 +177,8 @@ Staging:
 ISA Meta:
   Valid Study Assay Technology And Measurement Types:
     - measurement: "Amplicon Sequencing"
-      technology: "16S"
-    - measurement: "Amplicon Sequencing"
       technology: "18S"
-    # - measurement: "Amplicon Sequencing"
-    #   technology: "16S and ITS"
-    - measurement: "Amplicon Sequencing"
-      technology: "ITS"
+
 
   # this is prepended to all file names in the curation assay table
   Global file prefix: "{datasystem}_amplicon_"

--- a/dp_tools/config/amplicon_its.yaml
+++ b/dp_tools/config/amplicon_its.yaml
@@ -1,0 +1,30 @@
+# TOP LEVEL
+NAME: "amplicon_its"
+VERSION: "1"
+
+Staging:
+  General:
+    Required Metadata:
+      From ISA:
+        # ... keep as in amplicon_vLatest.yaml ...
+
+ISA Meta:
+  Valid Study Assay Technology And Measurement Types:
+    - measurement: "Amplicon Sequencing"
+      technology: "ITS"
+  Global file prefix: "{datasystem}_amplicon_"
+  # ... rest as in amplicon_vLatest.yaml ...
+
+data assets:
+  runsheet:
+    processed location: 
+      - "Metadata"
+      - "{dataset}_amplicon_its_v1_runsheet.csv"
+    tags:
+      - raw
+  ISA Archive:
+    processed location: 
+      - "Metadata"
+      - "{dataset}_metadata_*-ISA.zip"
+    tags:
+      - raw 

--- a/dp_tools/config/amplicon_its_v1.yaml
+++ b/dp_tools/config/amplicon_its_v1.yaml
@@ -177,12 +177,6 @@ Staging:
 ISA Meta:
   Valid Study Assay Technology And Measurement Types:
     - measurement: "Amplicon Sequencing"
-      technology: "16S"
-    - measurement: "Amplicon Sequencing"
-      technology: "18S"
-    # - measurement: "Amplicon Sequencing"
-    #   technology: "16S and ITS"
-    - measurement: "Amplicon Sequencing"
       technology: "ITS"
 
   # this is prepended to all file names in the curation assay table

--- a/dp_tools/config/amplicon_its_vLatest.yaml
+++ b/dp_tools/config/amplicon_its_vLatest.yaml
@@ -1,5 +1,5 @@
 # TOP LEVEL
-NAME: "amplicon"
+NAME: "amplicon_its"
 VERSION: "1"
 
 Staging:
@@ -176,12 +176,6 @@ Staging:
 
 ISA Meta:
   Valid Study Assay Technology And Measurement Types:
-    - measurement: "Amplicon Sequencing"
-      technology: "16S"
-    - measurement: "Amplicon Sequencing"
-      technology: "18S"
-    # - measurement: "Amplicon Sequencing"
-    #   technology: "16S and ITS"
     - measurement: "Amplicon Sequencing"
       technology: "ITS"
 

--- a/dp_tools/config/schemas.py
+++ b/dp_tools/config/schemas.py
@@ -50,7 +50,54 @@ runsheet = {
         columns={
             "Original Sample Name": pa.Column(str),
             "organism": pa.Column(str),
-            "host organism": pa.Column(str),
+            "paired_end": pa.Column(bool, check_single_value),
+            "read1_path": pa.Column(str),
+            "read2_path": pa.Column(str, required=False), # Expect if paired_end is True
+            "F_Primer": pa.Column(str, check_single_value), # Expect if paired_end is True
+            "R_Primer": pa.Column(str, check_single_value, required=False), # Expect if paired_end is True
+            "raw_R1_suffix": pa.Column(str), # No single value check for now
+            "raw_R2_suffix": pa.Column(str, check_single_value, required=False), # Expect if paired_end is True
+            "groups": pa.Column(str)
+        },
+        # define checks at the DataFrameSchema-level
+        checks=check_read2_path_populated_if_paired_end
+    ),
+    "amplicon_16s": pa.DataFrameSchema(
+        columns={
+            "Original Sample Name": pa.Column(str),
+            "organism": pa.Column(str),
+            "paired_end": pa.Column(bool, check_single_value),
+            "read1_path": pa.Column(str),
+            "read2_path": pa.Column(str, required=False), # Expect if paired_end is True
+            "F_Primer": pa.Column(str, check_single_value), # Expect if paired_end is True
+            "R_Primer": pa.Column(str, check_single_value, required=False), # Expect if paired_end is True
+            "raw_R1_suffix": pa.Column(str), # No single value check for now
+            "raw_R2_suffix": pa.Column(str, check_single_value, required=False), # Expect if paired_end is True
+            "groups": pa.Column(str)
+        },
+        # define checks at the DataFrameSchema-level
+        checks=check_read2_path_populated_if_paired_end
+    ),
+    "amplicon_its": pa.DataFrameSchema(
+        columns={
+            "Original Sample Name": pa.Column(str),
+            "organism": pa.Column(str),
+            "paired_end": pa.Column(bool, check_single_value),
+            "read1_path": pa.Column(str),
+            "read2_path": pa.Column(str, required=False), # Expect if paired_end is True
+            "F_Primer": pa.Column(str, check_single_value), # Expect if paired_end is True
+            "R_Primer": pa.Column(str, check_single_value, required=False), # Expect if paired_end is True
+            "raw_R1_suffix": pa.Column(str), # No single value check for now
+            "raw_R2_suffix": pa.Column(str, check_single_value, required=False), # Expect if paired_end is True
+            "groups": pa.Column(str)
+        },
+        # define checks at the DataFrameSchema-level
+        checks=check_read2_path_populated_if_paired_end
+    ),
+    "amplicon_18s": pa.DataFrameSchema(
+        columns={
+            "Original Sample Name": pa.Column(str),
+            "organism": pa.Column(str),
             "paired_end": pa.Column(bool, check_single_value),
             "read1_path": pa.Column(str),
             "read2_path": pa.Column(str, required=False), # Expect if paired_end is True

--- a/dp_tools/scripts/convert.py
+++ b/dp_tools/scripts/convert.py
@@ -81,7 +81,7 @@ def get_assay_table_path(
     return assay_paths, match_indices
 
 
-SUPPORTED_CONFIG_TYPES = ["microarray", "bulkRNASeq", "methylSeq", "amplicon", "metagenomics"]
+SUPPORTED_CONFIG_TYPES = ["microarray", "bulkRNASeq", "methylSeq", "amplicon", "amplicon_16s", "amplicon_its", "amplicon_18s", "metagenomics"]
 
 
 def _parse_args():
@@ -486,7 +486,7 @@ def isa_to_runsheet(accession: str, isaArchive: Path, config: Union[tuple[str, s
             )
 
         # if amplicon runsheet: make groups column
-        if configuration['NAME'] == "amplicon":
+        if configuration['NAME'].startswith("amplicon"):
             factor_value_cols = [col for col in df_final.columns if 'Factor Value' in col]
             df_final['groups'] = df_final[factor_value_cols].apply(lambda row: ' & '.join(row.values.astype(str)), axis=1)
 
@@ -515,35 +515,50 @@ def isa_to_runsheet(accession: str, isaArchive: Path, config: Union[tuple[str, s
         # WRITE OUTPUT
         ################################################################
         ################################################################
+        config_name = configuration['NAME']
+        config_version = configuration['VERSION']
         
-        if configuration['NAME'] == "amplicon":
+        # Handle specific amplicon configs
+        if config_name.startswith("amplicon_"):
+            tech_type = config_name.split('_')[1].upper() # e.g., '16S', 'ITS', '18S'
+            output_fn = f"{accession}_{tech_type}_amplicon_v{config_version}_runsheet.csv"
+        # Handle generic amplicon config
+        elif config_name == "amplicon":
             naming_column = "Library Selection"
-        # elif configuration['NAME'] == "metagenomics":
-        #     naming_column = "Library Kit"
-        else:
-            naming_column = None
-        
-        assay_file_suffix = ""
+            tech_type_suffix = "" # Default suffix if tech type can't be determined
 
-        if multiple_valid_assays:
-            if naming_column:
-                # Find columns that contain the substring naming_column
-                matching_columns = [col for col in df_final.columns if naming_column.lower() in col.lower()]
-                
+            # Always try to find the tech type from the Library Selection column for this specific assay
+            matching_columns = [col for col in df_final.columns if naming_column.lower() in col.lower()]
+            if matching_columns: # Check if any matching columns were found
                 col = matching_columns[0]
                 if naming_column not in col:
-                    print(f"Inconsistent naming found in {os.path.basename(assay_table_path)} column: {col}")
-                # Create file suffix from the matched column name, replacing spaces with underscores
-                assay_file_suffix = "_" + col.replace(" ", "_")
+                     # Log warning instead of printing directly to stdout? Adapt as needed.
+                    log.warning(f"Inconsistent naming found in source ISA table column: {col}, expected to contain '{naming_column}'")
+                
+                # Use the unique value(s) from the column
+                unique_vals = df_final[col].dropna().unique()
+                if len(unique_vals) == 1:
+                    val_str = str(unique_vals[0]).replace(" ", "_").upper()
+                elif len(unique_vals) > 1:
+                    # Handle multiple types found within the same assay table if necessary
+                    # For now, join them, uppercased
+                    val_str = "_".join([str(v).replace(" ", "_").upper() for v in unique_vals])
+                    log.warning(f"Multiple tech types ({val_str}) found in column '{col}' for a single assay table runsheet.")
+                else: # Fallback if column is empty or only NaN
+                    val_str = None # Indicate tech type wasn't found
+                
+                if val_str:
+                    tech_type_suffix = f"_{val_str}"
+                else:
+                     log.warning(f"Could not determine tech type from column '{col}'. Omitting from filename.")
             else:
-                assay_file_suffix = ""
+                log.warning(f"Could not find column containing '{naming_column}' to determine tech type. Omitting from filename.")
 
-            assay_table_file = os.path.basename(assay_table_path)
-            assay_table_name, _ = os.path.splitext(assay_table_file)
-            output_fn = f"{accession}{assay_file_suffix}_{assay_table_name}_{configuration['NAME']}_v{configuration['VERSION']}_runsheet.csv"
-
+            # Construct filename using the determined tech type (if found)
+            output_fn = f"{accession}{tech_type_suffix}_amplicon_v{config_version}_runsheet.csv"
+        # Handle other config types (e.g., bulkRNASeq, methylSeq)
         else:
-            output_fn = f"{accession}_{configuration['NAME']}_v{configuration['VERSION']}_runsheet.csv"
+            output_fn = f"{accession}_{config_name}_v{config_version}_runsheet.csv"
 
         # Logging the final output path and DataFrame dimensions
         log.info(f"Writing runsheet to: {output_fn} with {df_final.shape[0]} rows and {df_final.shape[1]} columns")


### PR DESCRIPTION
## [1.3.7]

### Added

- Added `amplicon_16s`, `amplicon_18s`, `amplicon_its` profiles for runsheet generation. These can be used to generate a single relevant amplicon runsheet from a given dataset. As opposed to using `amplicon`to potentially generate multiple runsheets.

### Changed

- Removed host organism dependency for amplicon runsheet generation (Resolves #50).
- Forced technology type (`16S`/`18S`/`ITS`) inclusion in all amplicon runsheet names.
- Removed assay table name inclusion from runsheet names for datasets with multiple amplicon assay tables (verified all current OSD datasets have at most one amplicon assay table per technology type).
- *Note: Support for combined '16S and ITS' assay type (OSD-249) is pending.*

### Fixed

- Dockerfile now sets the PATH environment variable using ENV.
- Resolved Docker build dependency conflict (PyYAML) using `--ignore-installed` during pip install.

